### PR TITLE
Add macOS installer package generation

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -497,14 +497,21 @@ jobs:
         cd ${{github.workspace}}
         mkdir -p staging/byeol
         cp -r bin/* staging/byeol
+        mv staging/byeol/*.pkg staging/ || true
         rm staging/byeol/logs || true
         rm staging/byeol/test || true
 
-    - name: upload output files.
+    - name: upload portable output files.
+      uses: actions/upload-artifact@v4
+      with:
+        name: byeol-macos-arm64-portable
+        path: ${{github.workspace}}/staging/byeol/
+
+    - name: upload pkg file
       uses: actions/upload-artifact@v4
       with:
         name: byeol-macos-arm64
-        path: ${{github.workspace}}/staging/
+        path: ${{github.workspace}}/staging/*.pkg
 
   build-on-windows:
     name: build on windows

--- a/.github/workflows/ci-stable.yml
+++ b/.github/workflows/ci-stable.yml
@@ -309,14 +309,21 @@ jobs:
       run: |
         mkdir -p staging/byeol
         cp -r bin/* staging/byeol/
+        mv staging/byeol/*.pkg staging/ || true
         [ -e staging/byeol/logs ] && rm -rf staging/byeol/logs
         [ -e staging/byeol/test ] && rm -rf staging/byeol/test
 
-    - name: upload output files.
+    - name: upload portable output files.
+      uses: actions/upload-artifact@v4
+      with:
+        name: byeol-macos-arm64-portable
+        path: staging/byeol/
+
+    - name: upload pkg file
       uses: actions/upload-artifact@v4
       with:
         name: byeol-macos-arm64
-        path: staging/
+        path: staging/*.pkg
 
   build-on-windows:
     name: build on windows

--- a/build/builder.py
+++ b/build/builder.py
@@ -832,6 +832,29 @@ def pub(arg, ignore_tidy=False):
         os.chdir(binDir + "/..")
         system("tar -zcvf byeol-macos-x64.tar.gz bin")
         printOk("done")
+
+        printInfoEnd("make a package")
+        pkgStaging = binDir + "/../staging_pkg"
+        if os.path.exists(pkgStaging):
+            rmtree(pkgStaging)
+
+        os.makedirs(f"{pkgStaging}/usr/local/bin")
+        os.makedirs(f"{pkgStaging}/usr/local/lib")
+        os.makedirs(f"{pkgStaging}/usr/local/share/byeol")
+
+        system(f"cp {binDir}/byeol {pkgStaging}/usr/local/bin/")
+        system(f"install_name_tool -add_rpath /usr/local/lib {pkgStaging}/usr/local/bin/byeol")
+
+        system(f"cp -r {binDir}/pack/* {pkgStaging}/usr/local/share/byeol/")
+        system(f"cp {binDir}/*.dylib {pkgStaging}/usr/local/lib/ 2>/dev/null || true")
+        system(f"cp {binDir}/*.so {pkgStaging}/usr/local/lib/ 2>/dev/null || true")
+
+        verStr = f"{ver_major}.{ver_minor}.{ver_fix}"
+        pkgName = f"byeol-{verStr}-macos-x64.pkg"
+        system(f"pkgbuild --root {pkgStaging} --identifier io.byeol --version {verStr} --install-location / {binDir}/{pkgName}")
+        rmtree(pkgStaging)
+        printOk("done")
+
         removeTestData()
         return 0
 

--- a/module/core/frame/thread.cpp
+++ b/module/core/frame/thread.cpp
@@ -169,6 +169,8 @@ namespace by {
             .setBaseSlots(*ret)
 #ifdef BY_BUILD_PLATFORM_IS_LINUX
             .addPath("/usr/share/pack/")
+#elif defined(BY_BUILD_PLATFORM_IS_MAC)
+            .addPath("/usr/local/share/byeol/")
 #endif
             .addPath("pack/")
             .load();


### PR DESCRIPTION
This PR adds the generation of a macOS installer package (.pkg) to the build process.
It updates the `pub mac` command in `builder.py` to use `pkgbuild` to create an unsigned package that installs the byeol binary, libraries, and resources to standard `/usr/local` paths.
It also modifies `thread.cpp` to ensure the installed byeol executable can find its resources at `/usr/local/share/byeol/`.
Finally, it updates the GitHub Actions workflows to include the .pkg file in the build artifacts.

---
*PR created automatically by Jules for task [8196791761575592301](https://jules.google.com/task/8196791761575592301) started by @kniz*